### PR TITLE
Fixed compilation with GCC 4.7

### DIFF
--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 using namespace PieDock;
 

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <unistd.h>
 
 using namespace PieDock;
 


### PR DESCRIPTION
GCC 4.7 "avoid[s] polluting the global namespace and do[es] not include <unistd.h>." (see http://gcc.gnu.org/gcc-4.7/changes.html). Thus, I've added `#include unistd.h` when necessary.
