### PR TITLE
Use pkg-config to find freetype

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_LANG_CPLUSPLUS
 AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_INSTALL
+PKG_PROG_PKG_CONFIG
 
 # Checks for mandatory libraries
 AC_CHECK_LIB([X11], [XOpenDisplay], , AC_MSG_ERROR([libX11 not found]))
@@ -47,15 +48,9 @@ AC_ARG_ENABLE(
 
 # Checks for Freetype
 if test "x$XFT" = "xtrue"; then
-	AC_PATH_PROG(FREETYPE_CONFIG, freetype-config, no)
-
-	if test x$FREETYPE_CONFIG = xno; then
-		AC_MSG_ERROR([*** freetype-config not found])
-	fi
-
-	FREETYPE_CFLAGS="`$FREETYPE_CONFIG --cflags`"
-	FREETYPE_LIBS="`$FREETYPE_CONFIG --libs`"
-	CXXFLAGS="$CXXFLAGS $FREETYPE_CFLAGS"
+	PKG_CHECK_MODULES(FREETYPE, freetype2, [
+		CXXFLAGS="$CXXFLAGS $FREETYPE_CFLAGS"
+	], AC_MSG_ERROR([Cannot find freetype]))
 fi
 
 # Checks for Xrender


### PR DESCRIPTION
As of freetype-2.9.1 the freetype-config file no longer gets installed
by default.

See also [Make installation of `freetype-config' optional](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=a7833f26c4ac45cafe1dffdcd7f7dcfd6493161c) commit by freetype upstream. 