### PR TITLE
Fix build with GCC 12 (missing <time.h> include)

### DIFF
--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 using namespace PieDock;


### PR DESCRIPTION
Fixes the following build failure w/ GCC 12:
```
WindowManager.cpp: In static member function ‘static void PieDock::WindowManager::activate(Display*, Window)’:
WindowManager.cpp:83:29: error: ‘time’ was not declared in this scope; did you mean ‘Time’?
   83 |         for (time_t start = time(0) + 2;
      |                             ^~~~
      |                             Time
```

Bug: https://bugs.gentoo.org/851516